### PR TITLE
Add get study brapi call

### DIFF
--- a/BMSAPI.postman_collection.json
+++ b/BMSAPI.postman_collection.json
@@ -20638,6 +20638,953 @@
 								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
 							},
 							"response": []
+						},
+						{
+							"name": "Verify response code and body when sortedBy trialDbId in asc order",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check if next trialDbId is greater or equal to previous trialDbId\", function () {",
+											"  ",
+											"    var jsonData = pm.response.json();",
+											"    var data = jsonData.result.data;",
+											"    var i;",
+											"    var proceed = true",
+											"    for (i = 0; i+1 < data.length ; i++) {",
+											"        ",
+											"           if((parseInt(data[i+1].trialDbId)) >= (parseInt(data[i].trialDbId))){",
+											"               proceed = true;",
+											"             ",
+											"           }else{",
+											"              proceed = false;",
+											"     }",
+											"   }",
+											"       pm.expect(proceed).to.eql(true);   ",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?sortBy=trialDbId&sortOrder=ASC",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "sortBy",
+											"value": "trialDbId"
+										},
+										{
+											"key": "sortOrder",
+											"value": "ASC"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when sortedBy trialDbId in desc order",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2019-07-18\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(\"21\");",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study for user 6 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons).to.eql([]);",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study for user 6\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3078\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check if next trialDbId is less than or equal to previous trialDbId\", function () {",
+											"  ",
+											"    var jsonData = pm.response.json();",
+											"    var data = jsonData.result.data;",
+											"    var i;",
+											"    var proceed = true",
+											"    for (i = 0; i+1 < data.length ; i++) {",
+											"        ",
+											"           if((parseInt(data[i+1].trialDbId)) <= (parseInt(data[i].trialDbId))){",
+											"               proceed = true;",
+											"              console.log(data[i+1].trialDbId + \"is less than/equal \" +data[i].trialDbId);",
+											"           }else{",
+											"              proceed = false;",
+											"     }",
+											"   }",
+											"       pm.expect(proceed).to.eql(true);   ",
+											"});",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?sortBy=trialDbId&sortOrder=DESC",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "sortBy",
+											"value": "trialDbId"
+										},
+										{
+											"key": "sortOrder",
+											"value": "DESC"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered invalid sortOrder value",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"",
+											"pm.test(\"Verify returned error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.errors[0].message).to.eql(\"sortOrder should be either ASC or DESC\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?sortBy=trialDbId&sortOrder=invalid",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "sortBy",
+											"value": "trialDbId"
+										},
+										{
+											"key": "sortOrder",
+											"value": "invalid"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered pagination details",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(10000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?page=0&pageSize=10000",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0"
+										},
+										{
+											"key": "pageSize",
+											"value": "10000"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered invalid page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"",
+											"pm.test(\"Verify returned error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.errors[0].message).to.eql(\"A total of 1 pages are available, so the page number must between 0 and 1 (exclusive).\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?page=1&pageSize=10000",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "pageSize",
+											"value": "10000"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when entered pageSize greater than max",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 500\", function () {",
+											"    pm.response.to.have.status(500);",
+											"});",
+											"",
+											"pm.test(\"Verify returned error message\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.errors[0].message).to.eql(\"Page size must between 1 and 10000.\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?page=0&pageSize=10001",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "0"
+										},
+										{
+											"key": "pageSize",
+											"value": "10001"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by combination of values",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(1);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-09-12\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"studyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Randomized Trial 20180003 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"6\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Trial\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Randomized Trial 20180003\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3013\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all trialDbId are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].trialDbId).to.eql(\"3013\");",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?studyTypeDbId=6&programDbId={{api_program_id}}&locationDbId=9001&seasonDbId=10290&trialDbId=3013&studyDbId={{studyDbId}}&active=true",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "studyTypeDbId",
+											"value": "6"
+										},
+										{
+											"key": "programDbId",
+											"value": "{{api_program_id}}"
+										},
+										{
+											"key": "locationDbId",
+											"value": "9001"
+										},
+										{
+											"key": "seasonDbId",
+											"value": "10290"
+										},
+										{
+											"key": "trialDbId",
+											"value": "3013"
+										},
+										{
+											"key": "studyDbId",
+											"value": "{{studyDbId}}"
+										},
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
 						}
 					],
 					"protocolProfileBehavior": {},

--- a/BMSAPI.postman_collection.json
+++ b/BMSAPI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ab964b23-5da7-4599-8a77-21f807df02d8",
+		"_postman_id": "f664862d-300a-4018-8fcc-0e01d2e10490",
 		"name": "BMSAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -20,8 +20,7 @@
 									"pm.environment.unset(\"masterToken\");",
 									"pm.environment.set(\"masterToken\", jsonData.access_token);",
 									"pm.environment.unset(\"masterTokenExpiry\");",
-									"pm.environment.set(\"masterTokenExpiry\", jsonData.expires_in);",
-									""
+									"pm.environment.set(\"masterTokenExpiry\", jsonData.expires_in);"
 								],
 								"type": "text/javascript"
 							}
@@ -2652,9 +2651,9 @@
 											"pm.test(\"Check defaultDisplayName \", function () {",
 											"    var jsonData = pm.response.json();",
 											"    pm.expect(jsonData.result.defaultDisplayName).to.eql(\"IB1\");",
-											"    pm.expect(jsonData.result.pedigree).to.eql(\"IB1\");",
+											"    pm.expect(jsonData.result.pedigree).to.eql(\"CML1/CML6\");",
 											"    pm.expect(jsonData.result.crossingPlan).to.eql(\"C2W|Single cross|GEN\");",
-											"    pm.expect(jsonData.result.crossingYear).to.eql(null);",
+											"    pm.expect(jsonData.result.crossingYear).to.eql(2018);",
 											"    pm.expect(jsonData.result.familyCode).to.equal(null);",
 											"    pm.expect(jsonData.result.parent1DbId).to.eql(21);",
 											"    pm.expect(jsonData.result.parent1Name).to.eql(\"CML1\");",
@@ -2788,9 +2787,9 @@
 											"pm.test(\"Check defaultDisplayName \", function () {",
 											"    var jsonData = pm.response.json();",
 											"    pm.expect(jsonData.result.defaultDisplayName).to.eql(\"IB1\");",
-											"    pm.expect(jsonData.result.pedigree).to.eql(\"IB1\");",
+											"    pm.expect(jsonData.result.pedigree).to.eql(\"CML1/CML6\");",
 											"    pm.expect(jsonData.result.crossingPlan).to.eql(\"C2W|Single cross|GEN\");",
-											"    pm.expect(jsonData.result.crossingYear).to.eql(null);",
+											"    pm.expect(jsonData.result.crossingYear).to.eql(2018);",
 											"    pm.expect(jsonData.result.familyCode).to.equal(null);",
 											"    pm.expect(jsonData.result.parent1DbId).to.eql(21);",
 											"    pm.expect(jsonData.result.parent1Name).to.eql(\"CML1\");",
@@ -2925,7 +2924,7 @@
 											"    pm.expect(jsonData.result.defaultDisplayName).to.eql(\"CML1\");",
 											"    pm.expect(jsonData.result.pedigree).to.eql(\"CML1\");",
 											"    pm.expect(jsonData.result.crossingPlan).to.eql(\"AGB1|Accession into genebank|MAN\");",
-											"    pm.expect(jsonData.result.crossingYear).to.eql(null);",
+											"    pm.expect(jsonData.result.crossingYear).to.eql(2020);",
 											"    pm.expect(jsonData.result.familyCode).to.equal(null);",
 											"    pm.expect(jsonData.result.parent1DbId).to.eql(21);",
 											"    pm.expect(jsonData.result.parent1Name).to.eql(\"CML1\");",

--- a/BMSAPI.postman_collection.json
+++ b/BMSAPI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "8cefad1b-7a1f-4342-8a24-aec0dc17eaa4",
+		"_postman_id": "ab964b23-5da7-4599-8a77-21f807df02d8",
 		"name": "BMSAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -19384,6 +19384,1265 @@
 		{
 			"name": "study-resource-brapi",
 			"item": [
+				{
+					"name": "GET ​/{crop}​/brapi​/v1​/studies",
+					"item": [
+						{
+							"name": "Verify response code and body when entered crop only",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by studyTypeDbId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(6);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all studyDbIds are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"        pm.expect(jsonData.result.data[i].studyTypeDbId).to.eql(\"1\");",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?studyTypeDbId=1",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "studyTypeDbId",
+											"value": "1"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by programDbId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all programDbId are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].programDbId).to.eql(pm.environment.get(\"api_program_id\"));",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?programDbId={{api_program_id}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "programDbId",
+											"value": "{{api_program_id}}"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by locationDbId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(8);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all locationDbId are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].locationDbId).to.eql(\"9001\");",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?locationDbId=9001",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "locationDbId",
+											"value": "9001"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by seasonDbId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(2);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all seasonDbId are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].seasons[0].seasonDbId).to.eql(\"10290\");",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?seasonDbId=10290",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "seasonDbId",
+											"value": "10290"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by trialDbId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(2);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-09-12\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"studyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Randomized Trial 20180003 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"6\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Trial\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Randomized Trial 20180003\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3013\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all trialDbId are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].trialDbId).to.eql(\"3013\");",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?trialDbId=3013",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "trialDbId",
+											"value": "3013"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by studyDbId",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(1);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all studyDbId are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?studyDbId={{nursery1StudyDbId}}",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "studyDbId",
+											"value": "{{nursery1StudyDbId}}"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by active set to true",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(12);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"true\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2018-10-25\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(pm.environment.get(\"nursery1StudyDbId\"));",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Study with Imported Cross Nursery 2018002 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Nursery\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].season).to.eql(\"Dry season\");",
+											" pm.expect(jsonData.result.data[0].seasons[0].seasonDbId).to.eql(\"10290\");",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9001\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Africa Rice Centre\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Study with Imported Cross Nursery 2018002\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3009\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all actvie are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].active).to.eql(\"true\");",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?active=true",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						},
+						{
+							"name": "Verify response code and body when filtered by active set to false",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "4cb2f4a6-f24b-4fd5-83a8-6f5a283f90cf",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify returned metadata\", function () {",
+											"    var jsonData = pm.response.json();",
+											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
+											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(2);",
+											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
+											" pm.expect(jsonData.metadata.status).to.eql([]);",
+											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
+											"});",
+											"",
+											"pm.test(\"Verify returned data\", function () {",
+											" var jsonData = pm.response.json();",
+											" pm.expect(jsonData.result.data[0].active).to.eql(\"false\");",
+											" pm.expect(jsonData.result.data[0].startDate).to.eql(\"2019-04-02\");",
+											" pm.expect(jsonData.result.data[0].studyDbId).to.eql(\"7\");",
+											" pm.expect(jsonData.result.data[0].studyName).to.eql(\"Trial for Subobs Creation#20190402142056988 Environment Number 1\");",
+											" pm.expect(jsonData.result.data[0].studyTypeDbId).to.eql(\"6\");",
+											" pm.expect(jsonData.result.data[0].studyTypeName).to.eql(\"Trial\");",
+											" pm.expect(jsonData.result.data[0].seasons).to.eql([]);",
+											" pm.expect(jsonData.result.data[0].locationDbId).to.eql(\"9016\");",
+											" pm.expect(jsonData.result.data[0].locationName).to.eql(\"Unspecified Location\");",
+											" pm.expect(jsonData.result.data[0].programDbId).to.eql(\"c9e335d2-3057-4958-a43e-e38cf61d09ca\");",
+											" pm.expect(jsonData.result.data[0].programName).to.eql(\"API Program\");",
+											" pm.expect(jsonData.result.data[0].trialName).to.eql(\"Trial for Subobs Creation#20190402142056988\");",
+											" pm.expect(jsonData.result.data[0].trialDbId).to.eql(\"3032\");",
+											"});",
+											"",
+											"",
+											"pm.test(\"Check all active are equal to input parameter\", function () {",
+											"  var jsonData = pm.response.json();",
+											"   var i;",
+											"    for (i = 0; i < jsonData.result.data.length; i++) { ",
+											"    pm.expect(jsonData.result.data[i].active).to.eql(\"false\");",
+											"    }",
+											"});    ",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "a8a4e83e-e25c-414c-983d-09d6f63dc8c1",
+										"exec": [
+											"const echoPostRequest = {\r",
+											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
+											"  method: 'POST',\r",
+											"  header: 'Content-Type:application/json',\r",
+											"  body: {\r",
+											"    mode: 'application/json',\r",
+											"    raw: JSON.stringify({\r",
+											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
+											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
+											"        \t\"grant_type\": \"\",\r",
+											"            \"client_id\": \"\"\r",
+											"        })\r",
+											"  }\r",
+											"};\r",
+											"\r",
+											"var getToken = true;\r",
+											"\r",
+											"if (!pm.environment.get('masterTokenExpiry') || \r",
+											"    !pm.environment.get('masterToken')) {\r",
+											"    console.log('Token or expiry date are missing')\r",
+											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
+											"    console.log('Token is expired')\r",
+											"} else {\r",
+											"    getToken = false;\r",
+											"    console.log('Token and expiry date are all good');\r",
+											"}\r",
+											"\r",
+											"if (getToken === true) {\r",
+											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
+											"    console.log(err ? err : res.json());\r",
+											"        if (err === null) {\r",
+											"            console.log('Saving the token and expiry date')\r",
+											"            var responseJson = res.json();\r",
+											"            pm.environment.set('masterToken', responseJson.access_token)\r",
+											"    \r",
+											"            var expiryDate = new Date();\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"pm.globals.get(\"variable_key\");\r",
+											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
+											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
+											"        }\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{masterToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{BMSurl}}/{{crop}}/brapi/v1/studies?active=false",
+									"host": [
+										"{{BMSurl}}"
+									],
+									"path": [
+										"{{crop}}",
+										"brapi",
+										"v1",
+										"studies"
+									],
+									"query": [
+										{
+											"key": "active",
+											"value": "false"
+										}
+									]
+								},
+								"description": "GET /{crop}/brapi/v1/studies/{studyDbId}"
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
 				{
 					"name": "GET ​/{crop}​/brapi​/v1​/studies​/{studyDbId}",
 					"item": [

--- a/BMS_Environment.postman_environment.json
+++ b/BMS_Environment.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "7e6ac722-2d09-4e82-9062-405485fd846c",
+	"id": "0e654717-89db-463a-b1f2-a3b590b56624",
 	"name": "BMS_Environment",
 	"values": [
 		{
@@ -9,7 +9,7 @@
 		},
 		{
 			"key": "BMSurl",
-			"value": "http://34.80.162.156:8080/bmsapi",
+			"value": "http://104.197.1.222:48080/bmsapi",
 			"enabled": true
 		},
 		{
@@ -714,6 +714,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-03-13T08:27:08.807Z",
-	"_postman_exported_using": "Postman/7.20.0"
+	"_postman_exported_at": "2020-04-01T07:06:35.728Z",
+	"_postman_exported_using": "Postman/7.21.1"
 }


### PR DESCRIPTION
List of changes:
1. Added the ff. tests for GET /{crop}/brapi/v1/studies/{studyDbId}:

- Verify response code and body when entered crop only
- Verify response code and body when filtered by studyTypeDbId
- Verify response code and body when filtered by programDbId
- Verify response code and body when filtered by locationDbId
- Verify response code and body when filtered by seasonDbId
- Verify response code and body when filtered by trialDbId
- Verify response code and body when filtered by studyDbId
- Verify response code and body when filtered by active set to true
- Verify response code and body when filtered by active set to false
- Verify response code and body when sortedBy trialDbId in asc order
- Verify response code and body when sortedBy trialDbId in desc order
- Verify response code and body when entered invalid sortOrder value
- Verify response code and body when entered pagination details
- Verify response code and body when entered invalid page


Tasks | /
-- | --
**Pre-merging** |  
Followed basic standards | ✅ 
Ensured that the List of API Services spreadsheet is updated |  
Ensured that all test data created and used in the tests are added in the Setting up Initial Data (Data Seeding) page | **No necessary change** 
Ensured that the entire test suite is passing in branch using PostmanCollections-CIRun or PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs | ✅
Ensured that Testlink is updated |  ✅ 
**Post-merging** |  
Ensured that the entire test suite is passing in master using PostmanCollections-CIRun and PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs |  
Deleted branch |  

