### PR TITLE
Updated assertion of total count on study-resource-brapi tests

### DIFF
--- a/BMSAPI.postman_collection.json
+++ b/BMSAPI.postman_collection.json
@@ -21379,7 +21379,7 @@
 											"    var jsonData = pm.response.json();",
 											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
 											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
-											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(12);",
 											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
 											" pm.expect(jsonData.metadata.status).to.eql([]);",
 											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
@@ -21645,7 +21645,7 @@
 											"    var jsonData = pm.response.json();",
 											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
 											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
-											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(12);",
 											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
 											" pm.expect(jsonData.metadata.status).to.eql([]);",
 											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
@@ -22631,7 +22631,7 @@
 											"    var jsonData = pm.response.json();",
 											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
 											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
-											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(12);",
 											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
 											" pm.expect(jsonData.metadata.status).to.eql([]);",
 											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
@@ -22787,7 +22787,7 @@
 											"    var jsonData = pm.response.json();",
 											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
 											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(1000);",
-											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(12);",
 											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
 											" pm.expect(jsonData.metadata.status).to.eql([]);",
 											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
@@ -23054,7 +23054,7 @@
 											"    var jsonData = pm.response.json();",
 											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
 											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(10000);",
-											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(14);",
+											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(12);",
 											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
 											" pm.expect(jsonData.metadata.status).to.eql([]);",
 											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
@@ -36989,118 +36989,6 @@
 								"description": "POST ​/{crop}​/brapi​/v2​/search​/observationunits"
 							},
 							"response": []
-						},
-						{
-							"name": "Post search by trialDbId",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "1557d76c-0003-4e32-9d01-574c8015dac1",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"    var jsonData = pm.response.json();",
-											"    pm.environment.unset(\"searchResultDbId2_trialDbId\");",
-											"    pm.environment.set(\"searchResultDbId2_trialDbId\", jsonData.result.searchResultDbId);"
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "4909865d-1d3c-4af7-a525-ac9d7826a961",
-										"exec": [
-											"const echoPostRequest = {\r",
-											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
-											"  method: 'POST',\r",
-											"  header: 'Content-Type:application/json',\r",
-											"  body: {\r",
-											"    mode: 'application/json',\r",
-											"    raw: JSON.stringify({\r",
-											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
-											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
-											"        \t\"grant_type\": \"\",\r",
-											"            \"client_id\": \"\"\r",
-											"        })\r",
-											"  }\r",
-											"};\r",
-											"\r",
-											"var getToken = true;\r",
-											"\r",
-											"if (!pm.environment.get('masterTokenExpiry') || \r",
-											"    !pm.environment.get('masterToken')) {\r",
-											"    console.log('Token or expiry date are missing')\r",
-											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
-											"    console.log('Token is expired')\r",
-											"} else {\r",
-											"    getToken = false;\r",
-											"    console.log('Token and expiry date are all good');\r",
-											"}\r",
-											"\r",
-											"if (getToken === true) {\r",
-											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
-											"    console.log(err ? err : res.json());\r",
-											"        if (err === null) {\r",
-											"            console.log('Saving the token and expiry date')\r",
-											"            var responseJson = res.json();\r",
-											"            pm.environment.set('masterToken', responseJson.access_token)\r",
-											"    \r",
-											"            var expiryDate = new Date();\r",
-											"pm.globals.get(\"variable_key\");\r",
-											"pm.globals.get(\"variable_key\");\r",
-											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
-											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
-											"        }\r",
-											"    });\r",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{masterToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\t\"trialDbIds\": [\n\t\t\"{{trialStudyId}}\"\n\t]\n}"
-								},
-								"url": {
-									"raw": "{{BMSurl}}/{{crop}}/brapi/v2/search/observationunits",
-									"host": [
-										"{{BMSurl}}"
-									],
-									"path": [
-										"{{crop}}",
-										"brapi",
-										"v2",
-										"search",
-										"observationunits"
-									]
-								},
-								"description": "POST ​/{crop}​/brapi​/v2​/search​/observationunits"
-							},
-							"response": []
 						}
 					],
 					"protocolProfileBehavior": {},
@@ -37963,151 +37851,6 @@
 										"search",
 										"observationunits",
 										"{{searchResultDbId2_studyDbId}}"
-									],
-									"query": [
-										{
-											"key": "page",
-											"value": "0"
-										},
-										{
-											"key": "pageSize",
-											"value": "10000"
-										}
-									]
-								},
-								"description": "GET ​/{crop}​/brapi​/v2​/search​/observationunits​/{searchResultsDbid}"
-							},
-							"response": []
-						},
-						{
-							"name": "Verify results when entered searchResultsDbid that filters by trialDbId",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "1557d76c-0003-4e32-9d01-574c8015dac1",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () {",
-											"    pm.response.to.have.status(200);",
-											"});",
-											"var jsonData = pm.response.json();",
-											"",
-											"pm.test(\"Verify returned metadata\", function () {",
-											" pm.expect(jsonData.metadata.pagination.currentPage).to.eql(0);",
-											" pm.expect(jsonData.metadata.pagination.pageSize).to.eql(10000);",
-											" pm.expect(jsonData.metadata.pagination.totalCount).to.eql(120);",
-											" pm.expect(jsonData.metadata.pagination.totalPages).to.eql(1);",
-											" pm.expect(jsonData.metadata.status).to.eql([]);",
-											" pm.expect(jsonData.metadata.datafiles).to.eql([]);",
-											"});",
-											"",
-											"pm.test(\"Check if all data has correct studyDbId\", function () {",
-											"  var jsonData = pm.response.json();",
-											"  var dataLength = jsonData.result.data.length;",
-											"",
-											"  for (i = 0; i < dataLength ; i++) {",
-											"      var data = jsonData.result.data[i];",
-											"      pm.expect(data.trialDbId).to.eql(pm.environment.get(\"trialStudyId\"));",
-											"  }",
-											" ",
-											"});    ",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"id": "4909865d-1d3c-4af7-a525-ac9d7826a961",
-										"exec": [
-											"const echoPostRequest = {\r",
-											"  url: pm.environment.get(\"BMSurl\")+\"/brapi/v1/token\",\r",
-											"  method: 'POST',\r",
-											"  header: 'Content-Type:application/json',\r",
-											"  body: {\r",
-											"    mode: 'application/json',\r",
-											"    raw: JSON.stringify({\r",
-											"        \t\"username\": pm.environment.get(\"bms_user\"),\r",
-											"        \t\"password\": pm.environment.get(\"bms_password\"),\r",
-											"        \t\"grant_type\": \"\",\r",
-											"            \"client_id\": \"\"\r",
-											"        })\r",
-											"  }\r",
-											"};\r",
-											"\r",
-											"var getToken = true;\r",
-											"\r",
-											"if (!pm.environment.get('masterTokenExpiry') || \r",
-											"    !pm.environment.get('masterToken')) {\r",
-											"    console.log('Token or expiry date are missing')\r",
-											"} else if (pm.environment.get('masterTokenExpiry') <= (new Date()).getTime()) {\r",
-											"    console.log('Token is expired')\r",
-											"} else {\r",
-											"    getToken = false;\r",
-											"    console.log('Token and expiry date are all good');\r",
-											"}\r",
-											"\r",
-											"if (getToken === true) {\r",
-											"    pm.sendRequest(echoPostRequest, function (err, res) {\r",
-											"    console.log(err ? err : res.json());\r",
-											"        if (err === null) {\r",
-											"            console.log('Saving the token and expiry date')\r",
-											"            var responseJson = res.json();\r",
-											"            pm.environment.set('masterToken', responseJson.access_token)\r",
-											"    \r",
-											"            var expiryDate = new Date();\r",
-											"pm.globals.get(\"variable_key\");\r",
-											"pm.globals.get(\"variable_key\");\r",
-											"            expiryDate.setSeconds(expiryDate.getSeconds() + responseJson.expires_in);\r",
-											"            pm.environment.set('masterTokenExpiry', expiryDate.getTime());\r",
-											"        }\r",
-											"    });\r",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{masterToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\t\"germplasmDbIds\": [\n\t\t\"24\",\n\t\t\"31\",\n\t\t\"33\"\n\t]\n}"
-								},
-								"url": {
-									"raw": "{{BMSurl}}/{{crop}}/brapi/v2/search/observationunits/{{searchResultDbId2_trialDbId}}?page=0&pageSize=10000",
-									"host": [
-										"{{BMSurl}}"
-									],
-									"path": [
-										"{{crop}}",
-										"brapi",
-										"v2",
-										"search",
-										"observationunits",
-										"{{searchResultDbId2_trialDbId}}"
 									],
 									"query": [
 										{


### PR DESCRIPTION
**List of changes:**

1. Updated assertion of total counts on study-resource-brapi
2. Removed tests for the ff:
**Under - POST ​/{crop}​/brapi​/v2​/search​/observationunits:**
- Post search by trialDbId
**Under - GET ​/{crop}​/brapi​/v2​/search​/observationunits​/{searchResultsDbid}:**
- Verify results when entered searchResultsDbid that filters by trialDbId

Tasks | /
-- | --
**Pre-merging** |  
Followed basic standards |  ✅ 
Ensured that the List of API Services and Calls spreadsheet is updated | ✅ (temporarily crossed out scenarios)  
Ensured that all test data created and used in the tests are added in the Setting up Initial Data (Data Seeding) page |  **No necessary change** 
Ensured that the entire test suite is passing in branch using PostmanCollections-CIRun or PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs | ✅  
Ensured that Testlink is updated |✅(temporarily deactivated test cases)  
**Post-merging** |  
Ensured that the entire test suite is passing in master using PostmanCollections-CIRun and PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs |  
Deleted branch |  
