### PR TITLE
Adjust tests v2 observation units and fix other failing tests

### DIFF
--- a/BMS_Environment.postman_environment.json
+++ b/BMS_Environment.postman_environment.json
@@ -1961,12 +1961,6 @@
 			"enabled": true
 		},
 		{
-			"key": "pedigree_search_accessionNumber",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		},
-		{
 			"key": "searchResultDbId2_includeObservationsFalse",
 			"value": "",
 			"type": "any",
@@ -1974,12 +1968,6 @@
 		},
 		{
 			"key": "searchResultDbId2_includeObservations",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		},
-		{
-			"key": "variable_key",
 			"value": "",
 			"type": "any",
 			"enabled": true
@@ -2001,9 +1989,57 @@
 			"value": "",
 			"type": "any",
 			"enabled": true
+		},
+		{
+			"key": "variable_key",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "pedigree_search_accessionNumber",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "searchResultDbId2_germplasmName",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "searchResultDbId2_locationName",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "searchResultDbId2_observationVariableName",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "searchResultDbId2_studyName",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "searchResultDbId2_trialName",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "searchResultDbId2_programName",
+			"value": "",
+			"type": "any",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-11-11T03:48:30.373Z",
-	"_postman_exported_using": "Postman/10.2.1"
+	"_postman_exported_at": "2022-11-23T04:25:13.920Z",
+	"_postman_exported_using": "Postman/10.4.5"
 }


### PR DESCRIPTION
**List of Changes:**

1. added tests for POST and GET search/observationunits
2. adjust end dates to year 2023 in POST v2/trial and studies
3. comment assertion for COOPERATOR_ID in POST v2/trial
4. adjust expected total no. in variable-resource tests
5. change value of observationVariableName in POST and GET observation-units/search

Tasks | ✅ / ❌ 
-- | --
Pre-merging |  
Followed basic standards |  
Ensured that the List of API Services spreadsheet is updated | **N/A**  
Ensured that all test data created and used in the tests are added in the Setting up Initial Data (Data Seeding) page | **N/A**
Ensured that the entire test suite is passing in branch using PostmanCollections-CIRun or PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs |  ✅ https://ci.leafnode.io/job/PostmanCollections-CIRun/1693/console
Ensured that Zephyr Scale test cases are updated | **N/A**
Created backup of the current test data | ✅  
Post-merging |  
Ensured that the entire test suite is passing in master using PostmanCollections-CIRun and PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs | 
Deleted branch |  