### PR TITLE
fix failing test for sprint 24.4

### DIFF
--- a/BMSAPI.postman_collection.json
+++ b/BMSAPI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9d3cada6-5cb3-4ade-873b-3b9e6db0a5b2",
+		"_postman_id": "70fd2fd9-96d5-43da-8976-c99ddb599482",
 		"name": "BMSAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "5151467"
@@ -18008,18 +18008,6 @@
 					"name": "GET /crops/{cropName}/lot-lists/template/xls",
 					"event": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {\r",
-									"    pm.response.to.have.status(200);\r",
-									"});\r",
-									""
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
 							"listen": "prerequest",
 							"script": {
 								"exec": [
@@ -18069,6 +18057,18 @@
 								],
 								"type": "text/javascript"
 							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
 					],
 					"request": {
@@ -18084,7 +18084,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{BMSurl}}/crops/{{crop}}/lot-lists/templates/xls",
+							"raw": "{{BMSurl}}/crops/{{crop}}/lot-lists/templates/xls?lotExcelTemplateExportType=LOT_CREATION",
 							"host": [
 								"{{BMSurl}}"
 							],
@@ -18094,6 +18094,12 @@
 								"lot-lists",
 								"templates",
 								"xls"
+							],
+							"query": [
+								{
+									"key": "lotExcelTemplateExportType",
+									"value": "LOT_CREATION"
+								}
 							]
 						}
 					},


### PR DESCRIPTION
**List of Changes:**

1. add lotExcelTemplateExportType parameter to GET /crops/{cropName}/lot-lists/template/xls

Tasks | ✅ / ❌ 
-- | --
Pre-merging |  
Followed basic standards |  
Ensured that the List of API Services spreadsheet is updated | **N/A**   
Ensured that all test data created and used in the tests are added in the Setting up Initial Data (Data Seeding) page | **N/A**
Ensured that the entire test suite is passing in branch using PostmanCollections-CIRun or PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs |  ✅https://ci.leafnode.io/job/PostmanCollections-CIRun/2070/console
Ensured that Zephyr Scale test cases are updated | **N/A**
Created backup of the current test data | ✅  
Post-merging |  
Ensured that the entire test suite is passing in master using PostmanCollections-CIRun and PostmanCollections-PerfTests (if changes are related to performance test) jenkins jobs |  
Deleted branch | 